### PR TITLE
Add validation script (alt)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "suggest:format": "echo \"\nTo resolve this, run: $(tput bold)npm run format$(tput sgr0)\" && exit 1",
     "test:format": "prettier --check . || npm run suggest:format",
     "test:spelling": "cspell \"spec/**/*.md\" README.md LICENSE.md",
-    "test:structure": "find . -maxdepth 1 -type d -name 'GAP-*' -exec ./scripts/validate-structure.js {} \\;"
+    "test:structure": "./scripts/validate-structure.js ."
   },
   "devDependencies": {
     "ajv": "^8.17.1",


### PR DESCRIPTION
Alt version of https://github.com/graphql/gaps/pull/3 to implement using glob per:

> Not ideal; this would find GAP-* (unlikely currently) folders inside node_modules for example. Maybe just incorporate the finding into the validate-structure.js script? Note glob is built in to Node.js now:
> 
> https://nodejs.org/api/fs.html#fspromisesglobpattern-options