### PR TITLE
Add more version ranges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ GAPs use number ranges to categorize different types of proposals:
 
 | Range | Category                         |
 | ----- | -------------------------------- |
-| 1XXX  | Community Directives             |
+| 1XXX  | Directive Specifications         |
 | 2XXX  | Language & Spec Extensions       |
 | 3XXX  | Ecosystem Conventions & Patterns |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,11 @@ that address issues outside the core GraphQL specifications.
 
 GAPs use number ranges to categorize different types of proposals:
 
-- **1XXX** — Community directive specifications
+| Range | Category                         |
+| ----- | -------------------------------- |
+| 1XXX  | Community Directives             |
+| 2XXX  | Language & Spec Extensions       |
+| 3XXX  | Ecosystem Conventions & Patterns |
 
 Other ranges may be added in the future as new categories are identified. The
 TSC are responsible for creating new GAP ranges.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GraphQL Auxiliary Proposals (GAPs)
+ GraphQL Auxiliary Proposals (GAPs)
 
 This repository provides a public home for GraphQL Auxiliary Proposals (GAPs),
 community specifications and auxiliary proposals that address issues outside of
@@ -21,7 +21,7 @@ GAPs use number ranges to categorize different types of proposals:
 
 | Range | Category                         |
 | ----- | -------------------------------- |
-| 1XXX  | Community Directives             |
+| 1XXX  | Directive Specifications         |
 | 2XXX  | Language & Spec Extensions       |
 | 3XXX  | Ecosystem Conventions & Patterns |
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ https://gaps.graphql.org/
 
 GAPs use number ranges to categorize different types of proposals:
 
-- **1XXX** — Community directive specifications
+| Range | Category                         |
+| ----- | -------------------------------- |
+| 1XXX  | Community Directives             |
+| 2XXX  | Language & Spec Extensions       |
+| 3XXX  | Ecosystem Conventions & Patterns |
 
 Other ranges may be added in the future as new categories are identified.
 


### PR DESCRIPTION
@benjie this accounts for all currently proposed/in-the-works GAPs

**1xxx: Directives**
- [`@mock`](https://public.larah.me/~mark/MockSpec.wip.html)
- [`@matches`](https://github.com/graphql/gaps/pull/2)
- `@semanticNonNull`(?)

**2xxx: Language & Spec Extensions**
- [`Field Extensions`](https://github.com/graphql/gaps/pull/4)
- [GraphQL Cursor Connections Specification](https://relay.dev/graphql/connections.htm)

**3xxx: Ecosystem Conventions & Patterns**
- [Fully Qualified Operation Names](https://github.com/graphql/gaps/pull/7)

If a GAP is both a language extension and also a directive (like `@matches`) then the more specific bucket of 1xxx: Directives should be used.

(I could maybe additionally see a 0XXX range for process/meta proposals about GAPs or GraphQL itself, but for now, omitting in case of yagni.)

wdyt? trying to avoid overcomplicating but these feel sufficiently distinct, and captures everything (for now)

...and I hope to one day deal with the problem of having 999+ proposals within any of these ranges :)