### PR TITLE
Add preview script for local development

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "format": "prettier --write .",
+    "preview": "./scripts/preview.sh",
     "suggest:format": "echo \"\nTo resolve this, run: $(tput bold)npm run format$(tput sgr0)\" && exit 1",
     "test:format": "prettier --check . || npm run suggest:format",
     "test:spelling": "cspell \"spec/**/*.md\" README.md LICENSE.md",

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+GAP_DIR="GAP-${GAP:-0}"
+
+DIM='\033[2m'
+RESET='\033[0m'
+YELLOW='\033[33m'
+GREEN='\033[32m'
+CLEAR='\033[2K\r'
+
+log() {
+  local color="$1" icon="$2" msg="$3"
+  shift 3
+  printf "${CLEAR}${DIM}│${RESET} ${color}${icon}${RESET} ${msg}" "$@"
+}
+
+export -f log
+export DIM RESET YELLOW GREEN CLEAR GAP_DIR
+
+npx portless gaps --force npx nodemon -q \
+  --watch "$GAP_DIR" --ext md \
+  --exec "\
+    log \$YELLOW ◌ 'Building ${GAP_DIR}${DIM}...${RESET}' && \
+    npx spec-md ${GAP_DIR}/DRAFT.md > ${GAP_DIR}/Index.html && \
+    log \$GREEN ● 'Rebuilt ${GAP_DIR} ${DIM}%s${RESET}\n' \"\$(date +%H:%M:%S)\" && \
+    npx http-server ${GAP_DIR} -s"


### PR DESCRIPTION
Adds `npm run preview` which watches a GAP directory for changes, rebuilds the spec-md output, and serves it locally. Set GAP=N to preview a specific GAP (defaults to GAP-0).