### PR TITLE
Clarify who updates CODEOWNERS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ gauge public interest, but doing so is not necessary.
      each GAP _author_.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
-Once approved by the _authors_ and _sponsor_, the PR should be merged!
+Once approved by the _authors_ and _sponsor_, the PR should be merged by the
+sponsor.
 
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ that address issues outside the core GraphQL specifications.
 
 - **Editor** — a person with write access to this repository
   ([@graphql/gaps-editors](https://github.com/orgs/graphql/teams/gaps-editors)),
-  approved by the TSC to administer the GAP program. _Editors_ configure
-  `CODEOWNERS` and merge PRs.
+  approved by the TSC to administer the GAP program.
 - **Sponsor** — an _editor_ assigned to a GAP who is responsible for approving
   the initial contents. A _sponsor_ may also be an _author_.
 - **Author** — a person (or people) who have made significant contributions to a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ gauge public interest, but doing so is not necessary.
    - Update `id` in `metadata.yml` to be the PR number.
    - If not yet configured, update the `discussion` path in `metadata.yml` to
      point to the PR.
+   - Update `CODEOWNERS` to grant ownership of the new `GAP-N` directory to
+     each GAP _author_.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
-Once approved by the _authors_ and _sponsor_, `CODEOWNERS` will be updated and
-the PR will be merged.
+Once approved by the _authors_ and _sponsor_, the PR should be merged!
 
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a


### PR DESCRIPTION
Clarify who updates `CODEOWNERS`.

I'd also like to some automated workflow for this; either a `!move-gap` command, or better yet imo, an automated github action that just automatically does all this stuff immediately after it sees the initial commit in a new PR.