### PR TITLE
Add automatic GAP setup workflow

### DIFF
--- a/.github/workflows/auto-gap-setup.yml
+++ b/.github/workflows/auto-gap-setup.yml
@@ -1,0 +1,93 @@
+name: Auto GAP Setup
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  setup:
+    name: Auto-configure new GAP
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Auto-configure GAP
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const { execSync } = require('child_process');
+
+            if (!fs.existsSync('GAP-0')) {
+              console.log('No GAP-0 directory found — nothing to do.');
+              return;
+            }
+
+            // Find the merged PR that introduced GAP-0
+            const sha = context.sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            const mergedPr = prs.find(pr => pr.merged_at && pr.base.ref === 'main');
+            if (!mergedPr) {
+              console.log('Could not find a merged PR for this push — nothing to do.');
+              return;
+            }
+
+            const prNumber = mergedPr.number;
+            const prAuthor = mergedPr.user.login;
+            const prUrl = mergedPr.html_url;
+            const gapDir = `GAP-${prNumber}`;
+
+            console.log(`Setting up ${gapDir} from GAP-0 (PR #${prNumber} by @${prAuthor})`);
+
+            // Rename GAP-0 → GAP-N
+            execSync(`git mv GAP-0 ${gapDir}`);
+
+            // Update metadata.yml
+            const metadataPath = path.join(gapDir, 'metadata.yml');
+            if (fs.existsSync(metadataPath)) {
+              let metadata = fs.readFileSync(metadataPath, 'utf8');
+              metadata = metadata.replace(/^id:\s*0$/m, `id: ${prNumber}`);
+              metadata = metadata.replace(/^(discussion:\s*).*$/m, `$1"${prUrl}"`);
+              fs.writeFileSync(metadataPath, metadata);
+              console.log(`Updated ${metadataPath}`);
+            }
+
+            // Update CODEOWNERS
+            const codeownersPath = 'CODEOWNERS';
+            let codeownersContent = '';
+            if (fs.existsSync(codeownersPath)) {
+              codeownersContent = fs.readFileSync(codeownersPath, 'utf8').trimEnd() + '\n';
+            }
+            const codeownersLine = `/${gapDir}/ @${prAuthor}`;
+            if (!codeownersContent.includes(codeownersLine)) {
+              codeownersContent += `${codeownersLine}\n`;
+              fs.writeFileSync(codeownersPath, codeownersContent);
+              console.log(`Updated CODEOWNERS: ${codeownersLine}`);
+            }
+
+            // Commit and push
+            execSync('git config user.name "github-actions[bot]"');
+            execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
+            execSync('git add -A');
+
+            const status = execSync('git status --porcelain').toString().trim();
+            if (!status) {
+              console.log('No changes to commit.');
+              return;
+            }
+
+            execSync(`git commit -m "Set up ${gapDir}\n\nRename GAP-0, update metadata.yml (id and discussion), and add CODEOWNERS entry."`);
+            execSync('git push');
+            console.log(`${gapDir} is ready!`);

--- a/.github/workflows/auto-gap-setup.yml
+++ b/.github/workflows/auto-gap-setup.yml
@@ -18,24 +18,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Auto-configure GAP
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
-            const { execSync } = require('child_process');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
             if (!fs.existsSync('GAP-0')) {
               console.log('No GAP-0 directory found — nothing to do.');
               return;
             }
 
-            // Find the merged PR that introduced GAP-0
-            const sha = context.sha;
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: sha,
+              owner, repo,
+              commit_sha: context.sha,
             });
 
             const mergedPr = prs.find(pr => pr.merged_at && pr.base.ref === 'main');
@@ -51,43 +50,86 @@ jobs:
 
             console.log(`Setting up ${gapDir} from GAP-0 (PR #${prNumber} by @${prAuthor})`);
 
-            // Rename GAP-0 → GAP-N
-            execSync(`git mv GAP-0 ${gapDir}`);
+            // Build a new tree: rename GAP-0/ → GAP-N/, update metadata.yml, add CODEOWNERS
+            const { data: currentTree } = await github.rest.git.getTree({
+              owner, repo,
+              tree_sha: context.sha,
+              recursive: 'true',
+            });
 
-            // Update metadata.yml
-            const metadataPath = path.join(gapDir, 'metadata.yml');
-            if (fs.existsSync(metadataPath)) {
-              let metadata = fs.readFileSync(metadataPath, 'utf8');
-              metadata = metadata.replace(/^id:\s*0$/m, `id: ${prNumber}`);
-              metadata = metadata.replace(/^(discussion:\s*).*$/m, `$1"${prUrl}"`);
-              fs.writeFileSync(metadataPath, metadata);
-              console.log(`Updated ${metadataPath}`);
+            const newTreeEntries = [];
+
+            for (const item of currentTree.tree) {
+              if (item.type === 'tree') continue;
+
+              const isGap0 = item.path.startsWith('GAP-0/');
+              const newPath = isGap0
+                ? item.path.replace('GAP-0/', `${gapDir}/`)
+                : item.path;
+
+              if (isGap0 && item.path.endsWith('metadata.yml')) {
+                const { data: blob } = await github.rest.git.getBlob({
+                  owner, repo,
+                  file_sha: item.sha,
+                });
+                let content = Buffer.from(blob.content, 'base64').toString('utf8');
+                content = content.replace(/^id:\s*0$/m, `id: ${prNumber}`);
+                content = content.replace(/^(discussion:\s*).*$/m, `$1"${prUrl}"`);
+
+                const { data: newBlob } = await github.rest.git.createBlob({
+                  owner, repo,
+                  content,
+                  encoding: 'utf-8',
+                });
+                newTreeEntries.push({ path: newPath, mode: item.mode, type: 'blob', sha: newBlob.sha });
+                continue;
+              }
+
+              newTreeEntries.push({ path: newPath, mode: item.mode, type: 'blob', sha: item.sha });
             }
 
-            // Update CODEOWNERS
-            const codeownersPath = 'CODEOWNERS';
+            // Add CODEOWNERS entry
             let codeownersContent = '';
-            if (fs.existsSync(codeownersPath)) {
-              codeownersContent = fs.readFileSync(codeownersPath, 'utf8').trimEnd() + '\n';
+            const existingCO = newTreeEntries.find(e => e.path === 'CODEOWNERS');
+            if (existingCO) {
+              const { data: blob } = await github.rest.git.getBlob({
+                owner, repo,
+                file_sha: existingCO.sha,
+              });
+              codeownersContent = Buffer.from(blob.content, 'base64').toString('utf8').trimEnd() + '\n';
             }
+
             const codeownersLine = `/${gapDir}/ @${prAuthor}`;
             if (!codeownersContent.includes(codeownersLine)) {
               codeownersContent += `${codeownersLine}\n`;
-              fs.writeFileSync(codeownersPath, codeownersContent);
-              console.log(`Updated CODEOWNERS: ${codeownersLine}`);
+              const { data: newBlob } = await github.rest.git.createBlob({
+                owner, repo,
+                content: codeownersContent,
+                encoding: 'utf-8',
+              });
+              const idx = newTreeEntries.findIndex(e => e.path === 'CODEOWNERS');
+              const entry = { path: 'CODEOWNERS', mode: '100644', type: 'blob', sha: newBlob.sha };
+              if (idx >= 0) newTreeEntries[idx] = entry;
+              else newTreeEntries.push(entry);
             }
 
-            // Commit and push
-            execSync('git config user.name "github-actions[bot]"');
-            execSync('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
-            execSync('git add -A');
+            // Create tree, commit, and update main
+            const { data: newTree } = await github.rest.git.createTree({
+              owner, repo,
+              tree: newTreeEntries,
+            });
 
-            const status = execSync('git status --porcelain').toString().trim();
-            if (!status) {
-              console.log('No changes to commit.');
-              return;
-            }
+            const { data: newCommit } = await github.rest.git.createCommit({
+              owner, repo,
+              message: `Set up ${gapDir}\n\nRename GAP-0, update metadata.yml (id and discussion), and add CODEOWNERS entry.`,
+              tree: newTree.sha,
+              parents: [context.sha],
+            });
 
-            execSync(`git commit -m "Set up ${gapDir}\n\nRename GAP-0, update metadata.yml (id and discussion), and add CODEOWNERS entry."`);
-            execSync('git push');
-            console.log(`${gapDir} is ready!`);
+            await github.rest.git.updateRef({
+              owner, repo,
+              ref: 'heads/main',
+              sha: newCommit.sha,
+            });
+
+            console.log(`Pushed commit ${newCommit.sha} — ${gapDir} is ready!`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,15 @@ After the PR is merged, a GitHub Action will automatically:
 If there are additional _authors_, manually add them to the `CODEOWNERS` entry
 after this step.
 
+After the PR is merged, a GitHub Action will automatically:
+
+- Rename `GAP-0` to `GAP-N` (where N is the PR number).
+- Update `id` and `discussion` in `metadata.yml`.
+- Add the PR author to `CODEOWNERS` for the `GAP-N/` directory.
+
+If there are additional _authors_, manually add them to the `CODEOWNERS` entry
+after this step.
+
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a
 > new GAP and deprecate the old one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,18 +30,19 @@ gauge public interest, but doing so is not necessary.
 1. Clone the repository and create a folder in the root called `GAP-0`.
 2. Add the required files to this folder as described below (`README.md`,
    `DRAFT.md` and `metadata.yml`), commit them, and open a pull request (PR).
-3. Update the GAP number to match the PR number (`graphql/gaps#10` has PR number
-   10). Do not zero-pad the PR number.
-   - Rename the folder from `GAP-0` to `GAP-N` where N is the PR number number.
-   - Update `id` in `metadata.yml` to be the PR number.
-   - If not yet configured, update the `discussion` path in `metadata.yml` to
-     point to the PR.
-   - Update `CODEOWNERS` to grant ownership of the new `GAP-N` directory to
-     each GAP _author_.
-4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
+3. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
 Once approved by the _authors_ and _sponsor_, the PR should be merged by the
 sponsor.
+
+After the PR is merged, a GitHub Action will automatically:
+
+- Rename `GAP-0` to `GAP-N` (where N is the PR number).
+- Update `id` and `discussion` in `metadata.yml`.
+- Add the PR author to `CODEOWNERS` for the `GAP-N/` directory.
+
+If there are additional _authors_, manually add them to the `CODEOWNERS` entry
+after this step.
 
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,15 +44,6 @@ After the PR is merged, a GitHub Action will automatically:
 If there are additional _authors_, manually add them to the `CODEOWNERS` entry
 after this step.
 
-After the PR is merged, a GitHub Action will automatically:
-
-- Rename `GAP-0` to `GAP-N` (where N is the PR number).
-- Update `id` and `discussion` in `metadata.yml`.
-- Add the PR author to `CODEOWNERS` for the `GAP-N/` directory.
-
-If there are additional _authors_, manually add them to the `CODEOWNERS` entry
-after this step.
-
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a
 > new GAP and deprecate the old one.


### PR DESCRIPTION
Add a GitHub Action that runs after PRs get merged to handle `GAP-0` -> `GAP-N` renaming.

Also updates `metadata.yml` and `CODEOWNERS`.