### PR TITLE
Add CODEOWNERS for GAP-13

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/GAP-13/ @benjie
+/gaps/GAP-13/ @benjie

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/GAP-13/ @benjie


### PR DESCRIPTION
Add a CODEOWNERS file granting @benjie ownership of the GAP-13 directory.

questions/confirmations for @benjie:

1) adding even though the directory doesn't exist yet (b/c the PR hasn't been merged; this step is (currently) first
2) do we want to namespace GAP-N directories in a top level `gaps` folder? I would think yes actually, but CONTRIBUTING doesn't clarify and [package.json](https://github.com/graphql/gaps/blob/9bcac04a04bf4dbd87f73f436c1a9a320a57e68f/package.json#L14) encodes that they'd all top level. I think we should change this?
3) would editors require another person to give approval on this type of PR? (`General etiquette in the absence of explicit rules is to not self-merge`)