### PR TITLE
Remove redundant @ prefix checks already enforced by JSON schema

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ that address issues outside the core GraphQL specifications.
 
 - **Editor** — a person with write access to this repository
   ([@graphql/gaps-editors](https://github.com/orgs/graphql/teams/gaps-editors)),
-  approved by the TSC to administer the GAP program. _Editors_ configure
-  `CODEOWNERS` and merge PRs.
+  approved by the TSC to administer the GAP program. _Editors_ merge PRs.
+  `CODEOWNERS` is automatically synced from `metadata.yml`.
 - **Sponsor** — an _editor_ assigned to a GAP who is responsible for approving
   the initial contents. A _sponsor_ may also be an _author_.
 - **Author** — a person (or people) who have made significant contributions to a
@@ -40,8 +40,8 @@ gauge public interest, but doing so is not necessary.
      point to the PR.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
-Once approved by the _authors_ and _sponsor_, `CODEOWNERS` will be updated and
-the PR will be merged.
+Once approved by the _authors_ and _sponsor_, the PR will be merged.
+`CODEOWNERS` is automatically synced from `metadata.yml` on push to `main`.
 
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,11 @@ gauge public interest, but doing so is not necessary.
      point to the PR.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
-Once approved by the _authors_ and _sponsor_, the PR will be merged.
-`CODEOWNERS` is automatically synced from `metadata.yml` on push to `main`.
+Once approved by the _authors_ and _sponsor_, the PR may be merged by either
+an _author_ or the _sponsor_.
+
+`CODEOWNERS` will automatically be updated allowing _authors_ to merge future
+contributions to their GAP.
 
 > [!IMPORTANT]
 > GAP numbers never change. If a proposal needs significant changes, create a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,8 @@ gauge public interest, but doing so is not necessary.
      point to the PR.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
-Once approved by the _authors_ and _sponsor_, the PR may be merged by either
-an _author_ or the _sponsor_.
+Once approved by the _authors_ and _sponsor_, the PR should be merged by the
+sponsor.
 
 `CODEOWNERS` will automatically be updated allowing _authors_ to merge future
 contributions to their GAP.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ that address issues outside the core GraphQL specifications.
 
 - **Editor** — a person with write access to this repository
   ([@graphql/gaps-editors](https://github.com/orgs/graphql/teams/gaps-editors)),
-  approved by the TSC to administer the GAP program. _Editors_ merge PRs.
-  `CODEOWNERS` is automatically synced from `metadata.yml`.
+  approved by the TSC to administer the GAP program.
 - **Sponsor** — an _editor_ assigned to a GAP who is responsible for approving
   the initial contents. A _sponsor_ may also be an _author_.
 - **Author** — a person (or people) who have made significant contributions to a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ gauge public interest, but doing so is not necessary.
 4. Ping `@graphql/gaps-editors` to find a sponsor, add them to `metadata.yml`.
 
 Once approved by the _authors_ and _sponsor_, the PR should be merged by the
-sponsor.
+_sponsor_.
 
 `CODEOWNERS` will automatically be updated allowing _authors_ to merge future
 contributions to their GAP.

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -95,7 +95,7 @@ function validateMetadata(dirPath, gapName) {
     error(gapName, `metadata.yml validation failed:\n\n${errors}`);
   }
 
-  // Validate authors have valid email and githubUsername
+  // Validate authors have valid email
   for (const author of metadata.authors) {
     if (!validator.isEmail(author.email)) {
       error(
@@ -103,20 +103,6 @@ function validateMetadata(dirPath, gapName) {
         `metadata.yml invalid author email "${author.email}" for "${author.name}"`,
       );
     }
-    if (!author.githubUsername.startsWith("@")) {
-      error(
-        gapName,
-        `metadata.yml author githubUsername must start with @ (got "${author.githubUsername}" for "${author.name}")`,
-      );
-    }
-  }
-
-  // Validate sponsor starts with @
-  if (!metadata.sponsor.startsWith("@")) {
-    error(
-      gapName,
-      `metadata.yml sponsor must be a GitHub username starting with @ (got "${metadata.sponsor}")`,
-    );
   }
 
   // Validate discussion is a valid URL


### PR DESCRIPTION
- Remove explicit `startsWith("@")` validation - this is already enforced in `metadata.schema.json`
- Update `CONTRIBUTING.md` to reflect that `CODEOWNERS` is now automatically generated