### PR TITLE
Fix authors rendering as `[object Object]`

### DIFF
--- a/scripts/build-website.js
+++ b/scripts/build-website.js
@@ -91,10 +91,6 @@ function titleCase(value) {
     .join(" ");
 }
 
-function authorName(author) {
-  const match = String(author).match(/^\s*(.*?)\s*<[^>]+>\s*$/);
-  return match ? match[1] : String(author);
-}
 
 const readTemplate = memoize(async (name) => {
   const templatePath = join(templatesDir, name);
@@ -144,7 +140,7 @@ async function renderGapMeta(gap) {
   const gapMetaTemplate = await readTemplate("gap-meta.html");
   const items = [
     { label: "Status", value: titleCase(gap.status) },
-    { label: "Authors", value: gap.authors.map(authorName).join(", ") },
+    { label: "Authors", value: gap.authors.map((a) => a.name).join(", ") },
     { label: "Sponsor", value: gap.sponsor },
   ];
 
@@ -284,7 +280,7 @@ async function buildGap(gapDir, outDir) {
         frontmatter: {
           [gapName]: gapMetadata.title,
           Version: document.label,
-          Authors: gapMetadata.authors.map(authorName).join(", "),
+          Authors: gapMetadata.authors.map((a) => a.name).join(", "),
           Discussion: gapMetadata.discussion,
         },
       });


### PR DESCRIPTION
Oops!

fixes this:

<img width="184" height="84" alt="Screenshot 2026-05-07 at 3 46 23 PM" src="https://github.com/user-attachments/assets/ee56d250-1ae8-48a0-ada1-e1cbf88f26a8" />


(we changed `authorName` -> `authors` array in the metadata.yml schema but forgot to update here.)