### PR TITLE
Add naming compliance section to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,23 @@ example, if the PR that adds a GAP is `graphql/gaps#10`, the proposal becomes
 **GAP-10**. Until the PR is filed and the number known, use `GAP-0` as a
 placeholder.
 
+## Use of the term "GraphQL"
+
+GAPs must comply with the [GraphQL trademark
+policy](https://graphql.org/brand/#the-graphql-trademark); so, for example,
+rather than calling your GAP "GraphQL Cursor Connections Specification" choose
+"Cursor Connections Specification for GraphQL".
+
+Key rules:
+
+- Keep the “GraphQL” word consistent, with the first letter and QL capitalized.
+  Don’t lowercase or abbreviate “GraphQL” (for example “Graphql” or “GQL”).
+- Don’t directly combine “GraphQL” with another trademark or generic term.
+  Discouraged: "X GraphQL", "GraphQL X"; encouraged: "X for GraphQL".
+- Don’t use “GraphQL” in a way that could imply partnership, sponsorship, or
+  endorsement by the GraphQL project or GraphQL Foundation either directly or by
+  omission.
+
 ## Filing a GAP
 
 Before filing a GAP you're encouraged to create an issue outlining the topic to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ example, if the PR that adds a GAP is `graphql/gaps#10`, the proposal becomes
 **GAP-10**. Until the PR is filed and the number known, use `GAP-0` as a
 placeholder.
 
-## Use of the term "GraphQL"
+## Use of trademarks
 
 GAPs must comply with the [GraphQL trademark
 policy](https://graphql.org/brand/#the-graphql-trademark); so, for example,
@@ -38,6 +38,9 @@ Key rules:
 - Don’t use “GraphQL” in a way that could imply partnership, sponsorship, or
   endorsement by the GraphQL project or GraphQL Foundation either directly or by
   omission.
+
+Similar principles apply to other trademarks and brand names: instead of "ExampleCorp
+Client Caching Specification", use "Caching Specification for ExampleCorp Clients".
 
 ## Filing a GAP
 


### PR DESCRIPTION
@graphql/gaps-editors are responsible for enforcing this, and can go through and rename/reword GAPs to ensure compliance.