### PR TITLE
Add a workflow to validate that .md files are valid spec-md

### DIFF
--- a/.github/workflows/validate-build.yml
+++ b/.github/workflows/validate-build.yml
@@ -1,0 +1,26 @@
+name: Validate Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build GAP website
+        run: npm run build


### PR DESCRIPTION
Adds a CI check that runs `npm run build` on pull requests to catch build failures before merge. 

Will prevent future occurrences of https://github.com/graphql/gaps/pull/33#issuecomment-4493053028

(this is currently failing, but will pass once https://github.com/graphql/gaps/pull/32 ships)