### PR TITLE
Validate that GAP directories only contain allowed files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
       "name": "@graphql/gaps",
       "devDependencies": {
         "@mlarah/spec-md": "^3.1.0",
+        "@tsconfig/node-ts": "^23.6.4",
+        "@tsconfig/node24": "^24.0.4",
+        "@types/node": "^24.13.2",
+        "@types/validator": "^13.15.10",
         "ajv": "^8.17.1",
         "cspell": "5.9.1",
         "handlebars": "^4.7.9",
@@ -15,6 +19,7 @@
         "nodemon": "2.0.20",
         "p-limit": "^7.3.0",
         "prettier": "^3.8.1",
+        "typescript": "^6.0.3",
         "validator": "^13.12.0",
         "yaml": "^2.7.0"
       },
@@ -369,9 +374,40 @@
         "node": ">=16"
       }
     },
+    "node_modules/@tsconfig/node-ts": {
+      "version": "23.6.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node-ts/-/node-ts-23.6.4.tgz",
+      "integrity": "sha512-37BMJvNQZ+vTgd1xG2TGBkJ6ENeT4eO4Wh2CHrnn0IwH7ybLFCzh4Uc//kc7UIvqiRac4uGdIc1meKOjMSlKzw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node24": {
+      "version": "24.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
+      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1611,6 +1647,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "integrity": "sha1-gjFem7xvKyWIiFis0f/4RBA1t38=",
@@ -1627,6 +1677,13 @@
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -12,11 +12,15 @@
     "suggest:format": "echo \"\nTo resolve this, run: $(tput bold)npm run format$(tput sgr0)\" && exit 1",
     "test:format": "prettier --check . || npm run suggest:format",
     "test:spelling": "cspell \"spec/**/*.md\" README.md LICENSE.md",
-    "test:structure": "find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} ./scripts/validate-structure.js {}",
+    "test:structure": "find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} ./scripts/validate-structure.ts {}",
     "sync:codeowners": "node scripts/sync-codeowners.js"
   },
   "devDependencies": {
     "@mlarah/spec-md": "^3.1.0",
+    "@tsconfig/node-ts": "^23.6.4",
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^24.13.2",
+    "@types/validator": "^13.15.10",
     "ajv": "^8.17.1",
     "cspell": "5.9.1",
     "handlebars": "^4.7.9",
@@ -25,6 +29,7 @@
     "nodemon": "2.0.20",
     "p-limit": "^7.3.0",
     "prettier": "^3.8.1",
+    "typescript": "^6.0.3",
     "validator": "^13.12.0",
     "yaml": "^2.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:format": "prettier --check . || npm run suggest:format",
     "test:spelling": "cspell \"spec/**/*.md\" README.md LICENSE.md",
     "test:structure": "node scripts/validate-structure.ts",
-    "sync:codeowners": "node scripts/sync-codeowners.js"
+    "sync:codeowners": "node scripts/sync-codeowners.ts"
   },
   "devDependencies": {
     "@mlarah/spec-md": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "suggest:format": "echo \"\nTo resolve this, run: $(tput bold)npm run format$(tput sgr0)\" && exit 1",
     "test:format": "prettier --check . || npm run suggest:format",
     "test:spelling": "cspell \"spec/**/*.md\" README.md LICENSE.md",
-    "test:structure": "find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} ./scripts/validate-structure.ts {}",
+    "test:structure": "node scripts/validate-structure.ts",
     "sync:codeowners": "node scripts/sync-codeowners.js"
   },
   "devDependencies": {

--- a/scripts/sync-codeowners.ts
+++ b/scripts/sync-codeowners.ts
@@ -1,28 +1,33 @@
 #!/usr/bin/env node
 
 import { readdir, readFile, writeFile } from "node:fs/promises";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const rootDir = join(__dirname, "..");
+const rootDir = join(import.meta.dirname, "..");
 const gapsDir = join(rootDir, "gaps");
 
 async function getGapDirs() {
   const entries = await readdir(gapsDir, { withFileTypes: true });
-  return entries.filter((d) => d.isDirectory() && /^GAP-[1-9]\d*$/.test(d.name));
+  return entries.filter(
+    (d) => d.isDirectory() && /^GAP-[1-9]\d*$/.test(d.name),
+  );
 }
 
 async function main() {
   const dirs = await getGapDirs();
-  dirs.sort((a, b) => parseInt(a.name.split("-")[1], 10) - parseInt(b.name.split("-")[1], 10));
+  dirs.sort(
+    (a, b) =>
+      parseInt(a.name.split("-")[1], 10) - parseInt(b.name.split("-")[1], 10),
+  );
 
   const lines = await Promise.all(
     dirs.map(async (dir) => {
       const metadataPath = join(gapsDir, dir.name, "metadata.yml");
       const metadata = parseYaml(await readFile(metadataPath, "utf8"));
-      const owners = metadata.authors.map((a) => a.githubUsername.replace(/^@/, ""));
+      const owners = metadata.authors.map((a) =>
+        a.githubUsername.replace(/^@/, ""),
+      );
       const ownerList = owners.map((o) => `@${o}`).join(" ");
       return `/gaps/${dir.name}/ ${ownerList}`;
     }),

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -9,7 +9,7 @@
  *   find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} node scripts/validate-structure.js {}
  */
 
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -114,6 +114,26 @@ function validateMetadata(dirPath, gapName) {
   }
 }
 
+function validateAllowedFiles(dirPath, gapName) {
+  const entries = readdirSync(dirPath);
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry);
+    if (statSync(fullPath).isDirectory()) {
+      error(
+        gapName,
+        `Unexpected directory "${entry}" found. GAP directories may only contain *.md files and metadata.yml. If you believe this is in error, please ping @graphql/gaps-editors.`,
+      );
+    }
+    if (entry === "metadata.yml" || entry.endsWith(".md")) {
+      continue;
+    }
+    error(
+      gapName,
+      `Unexpected file "${entry}" found. GAP directories may only contain *.md files and metadata.yml. If you believe this is in error, please ping @graphql/gaps-editors.`,
+    );
+  }
+}
+
 function main() {
   const { positionals } = parseArgs({ allowPositionals: true, strict: true });
 
@@ -136,6 +156,9 @@ function main() {
 
   // Validate directory naming
   const gapName = validateDirectoryNaming(dirPath);
+
+  // Validate only allowed files are present
+  validateAllowedFiles(dirPath, gapName);
 
   // Validate README.md exists
   validateReadmeExists(dirPath, gapName);

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -127,8 +127,7 @@ function validateAllowedFiles(dirPath, gapName) {
     if (
       entry === "metadata.yml" ||
       entry === "metadata.json" ||
-      entry.endsWith(".md") ||
-      !entry.startsWith(".")
+      entry.endsWith(".md")
     ) {
       continue;
     }

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -117,9 +117,6 @@ function validateMetadata(dirPath, gapName) {
 function validateAllowedFiles(dirPath, gapName) {
   const entries = readdirSync(dirPath);
   for (const entry of entries) {
-    if (entry.startsWith(".")) {
-      continue;
-    }
     const fullPath = join(dirPath, entry);
     if (statSync(fullPath).isDirectory()) {
       error(
@@ -130,7 +127,8 @@ function validateAllowedFiles(dirPath, gapName) {
     if (
       entry === "metadata.yml" ||
       entry === "metadata.json" ||
-      entry.endsWith(".md")
+      entry.endsWith(".md") ||
+      !entry.startsWith(".")
     ) {
       continue;
     }

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -115,32 +115,46 @@ function validateMetadata(dirPath, gapName) {
 }
 
 function validateAllowedFiles(dirPath, gapName) {
-  const entries = readdirSync(dirPath);
-  for (const entry of entries) {
+  for (const entry of readdirSync(dirPath)) {
     if (entry.startsWith(".")) {
-      error(
-        gapName,
-        `Dotfiles are not allowed: "${entry}". If you believe this is in error, please ping @graphql/gaps-editors.`,
-      );
-    }
-    const fullPath = join(dirPath, entry);
-    if (statSync(fullPath).isDirectory()) {
-      error(
-        gapName,
-        `Unexpected directory "${entry}" found. GAP directories may only contain *.md files, metadata.yml, and metadata.json. If you believe this is in error, please ping @graphql/gaps-editors.`,
-      );
-    }
-    if (
-      entry === "metadata.yml" ||
-      entry === "metadata.json" ||
-      entry.endsWith(".md")
-    ) {
+      error(gapName, `Dotfiles are not allowed: "${entry}".`);
       continue;
     }
-    error(
-      gapName,
-      `Unexpected file "${entry}" found. GAP directories may only contain *.md files, metadata.yml, and metadata.json. If you believe this is in error, please ping @graphql/gaps-editors.`,
-    );
+
+    const fullPath = join(dirPath, entry);
+
+    if (statSync(fullPath).isDirectory()) {
+      if (entry === "versions") {
+        validateVersionsDir(fullPath, gapName);
+      } else {
+        error(gapName, `Unexpected directory "${entry}".`);
+      }
+      continue;
+    }
+
+    if (entry === "metadata.yml" || entry === "metadata.json" || entry.endsWith(".md")) {
+      continue;
+    }
+
+    error(gapName, `Unexpected file "${entry}".`);
+  }
+}
+
+function validateVersionsDir(dirPath, gapName) {
+  for (const entry of readdirSync(dirPath)) {
+    if (entry.startsWith(".")) {
+      error(gapName, `Dotfiles are not allowed in versions/: "${entry}".`);
+      continue;
+    }
+
+    if (statSync(join(dirPath, entry)).isDirectory()) {
+      error(gapName, `Unexpected directory in versions/: "${entry}".`);
+      continue;
+    }
+
+    if (!/^\d{4}-\d{2}\.(md|yml)$/.test(entry)) {
+      error(gapName, `Unexpected file in versions/: "${entry}". Only YYYY-MM.md and YYYY-MM.yml are allowed.`);
+    }
   }
 }
 

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -117,6 +117,9 @@ function validateMetadata(dirPath, gapName) {
 function validateAllowedFiles(dirPath, gapName) {
   const entries = readdirSync(dirPath);
   for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      continue;
+    }
     const fullPath = join(dirPath, entry);
     if (statSync(fullPath).isDirectory()) {
       error(
@@ -127,8 +130,7 @@ function validateAllowedFiles(dirPath, gapName) {
     if (
       entry === "metadata.yml" ||
       entry === "metadata.json" ||
-      entry.endsWith(".md") ||
-      entry.startsWith(".")
+      entry.endsWith(".md")
     ) {
       continue;
     }

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -121,15 +121,20 @@ function validateAllowedFiles(dirPath, gapName) {
     if (statSync(fullPath).isDirectory()) {
       error(
         gapName,
-        `Unexpected directory "${entry}" found. GAP directories may only contain *.md files and metadata.yml. If you believe this is in error, please ping @graphql/gaps-editors.`,
+        `Unexpected directory "${entry}" found. GAP directories may only contain *.md files, metadata.yml, and metadata.json. If you believe this is in error, please ping @graphql/gaps-editors.`,
       );
     }
-    if (entry === "metadata.yml" || entry.endsWith(".md")) {
+    if (
+      entry === "metadata.yml" ||
+      entry === "metadata.json" ||
+      entry.endsWith(".md") ||
+      entry.startsWith(".")
+    ) {
       continue;
     }
     error(
       gapName,
-      `Unexpected file "${entry}" found. GAP directories may only contain *.md files and metadata.yml. If you believe this is in error, please ping @graphql/gaps-editors.`,
+      `Unexpected file "${entry}" found. GAP directories may only contain *.md files, metadata.yml, and metadata.json. If you believe this is in error, please ping @graphql/gaps-editors.`,
     );
   }
 }

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -117,6 +117,12 @@ function validateMetadata(dirPath, gapName) {
 function validateAllowedFiles(dirPath, gapName) {
   const entries = readdirSync(dirPath);
   for (const entry of entries) {
+    if (entry.startsWith(".")) {
+      error(
+        gapName,
+        `Dotfiles are not allowed: "${entry}". If you believe this is in error, please ping @graphql/gaps-editors.`,
+      );
+    }
     const fullPath = join(dirPath, entry);
     if (statSync(fullPath).isDirectory()) {
       error(

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -10,8 +10,7 @@
  */
 
 import { access, constants, readFile, readdir, stat } from "node:fs/promises";
-import { basename, join, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { basename, join } from "node:path";
 import { parseArgs } from "node:util";
 import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { parse as parseYaml } from "yaml";
@@ -26,7 +25,7 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname = import.meta.dirname;
 
 // Load JSON Schema from root directory
 const schemaPath = join(__dirname, "..", "metadata.schema.json");

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -25,11 +25,11 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
-const ROOT = resolve(import.meta.dirname, "..");
-const GAPS_DIR = join(ROOT, "gaps");
+const rootDir = resolve(import.meta.dirname, "..");
+const gapsDir = join(rootDir, "gaps");
 
 // Load JSON Schema from root directory
-const schemaPath = join(ROOT, "metadata.schema.json");
+const schemaPath = join(rootDir, "metadata.schema.json");
 const metadataSchema = JSON.parse(await readFile(schemaPath, "utf8"));
 
 // Set up ajv with JSON Schema
@@ -189,11 +189,11 @@ async function main() {
   } else if (positionals.length === 1) {
     gapsToCheck.push(positionals[0]);
   } else {
-    const gaps = await readdir(GAPS_DIR);
+    const gaps = await readdir(gapsDir);
     await Promise.all(
       gaps.map(async (filename) => {
         if (filename.startsWith(".")) return;
-        const fullPath = join(GAPS_DIR, filename);
+        const fullPath = join(gapsDir, filename);
         const stats = await stat(fullPath);
         if (stats.isDirectory()) {
           gapsToCheck.push(fullPath);

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -3,10 +3,10 @@
 /**
  * Validates the structure of a GAP directory.
  *
- * Usage: ./scripts/validate-structure.js <gap-directory>
+ * Usage: ./scripts/validate-structure.ts <gap-directory>
  *
  * Can be xarg'd over all GAP directories:
- *   find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} node scripts/validate-structure.js {}
+ *   find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} node scripts/validate-structure.ts {}
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
@@ -162,7 +162,7 @@ function main() {
   const { positionals } = parseArgs({ allowPositionals: true, strict: true });
 
   if (positionals.length !== 1) {
-    console.error("Usage: ./scripts/validate-structure.js <gap-directory>");
+    console.error("Usage: ./scripts/validate-structure.ts <gap-directory>");
     process.exit(1);
   }
 

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -128,10 +128,11 @@ async function validateMetadata(dirPath: string, gapName: string) {
 }
 
 async function validateAllowedFiles(dirPath: string, gapName: string) {
-  for (const entry of await readdir(dirPath)) {
+  const entries = await readdir(dirPath);
+  const promises = entries.map(async (entry) => {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed: "${entry}".`);
-      continue;
+      return;
     }
 
     const fullPath = join(dirPath, entry);
@@ -142,7 +143,7 @@ async function validateAllowedFiles(dirPath: string, gapName: string) {
       } else {
         error(gapName, `Unexpected directory "${entry}".`);
       }
-      continue;
+      return;
     }
 
     if (
@@ -150,23 +151,25 @@ async function validateAllowedFiles(dirPath: string, gapName: string) {
       entry === "metadata.json" ||
       entry.endsWith(".md")
     ) {
-      continue;
+      return;
     }
 
     error(gapName, `Unexpected file "${entry}".`);
-  }
+  });
+  await Promise.all(promises);
 }
 
 async function validateVersionsDir(dirPath: string, gapName: string) {
-  for (const entry of await readdir(dirPath)) {
+  const entries = await readdir(dirPath);
+  const promises = entries.map(async (entry) => {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed in versions/: "${entry}".`);
-      continue;
+      return;
     }
 
     if ((await stat(join(dirPath, entry))).isDirectory()) {
       error(gapName, `Unexpected directory in versions/: "${entry}".`);
-      continue;
+      return;
     }
 
     if (!/^\d{4}-\d{2}\.(md|yml)$/.test(entry)) {
@@ -175,7 +178,8 @@ async function validateVersionsDir(dirPath: string, gapName: string) {
         `Unexpected file in versions/: "${entry}". Only YYYY-MM.md and YYYY-MM.yml are allowed.`,
       );
     }
-  }
+  });
+  await Promise.all(promises);
 }
 
 async function main() {

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -35,9 +35,10 @@ const metadataSchema = JSON.parse(await readFile(schemaPath, "utf8"));
 const ajv = new Ajv({ allErrors: true });
 const validateMetadataSchema = ajv.compile(metadataSchema);
 
+const errors: { [gapName: string]: string[] } = Object.create(null);
 function error(gapName: string, message: string) {
-  console.error(`${gapName}: ${message}`);
-  process.exit(1);
+  errors[gapName] ??= [];
+  errors[gapName].push(message);
 }
 
 function validateDirectoryNaming(dirPath: string) {
@@ -212,6 +213,20 @@ async function main() {
 
   // Validate metadata.yml
   await validateMetadata(dirPath, gapName);
+
+  const badGaps = Object.keys(errors);
+  if (badGaps.length > 0) {
+    process.exitCode = 1;
+    badGaps.sort(); // This is lexicographic... Not ideal but I'm too lazy to parse it.
+    for (const gapName of badGaps) {
+      console.error(`# ${gapName}`);
+      console.error();
+      for (const message of errors[gapName]) {
+        console.error(`- ${message}`);
+      }
+      console.error();
+    }
+  }
 }
 
 await main();

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -3,10 +3,10 @@
 /**
  * Validates the structure of a GAP directory.
  *
- * Usage: ./scripts/validate-structure.ts <gap-directory>
+ * Usage: ./scripts/validate-structure.ts [gap-directory]
  *
- * Can be xarg'd over all GAP directories:
- *   find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} node scripts/validate-structure.ts {}
+ * If no GAP directory is specified, will scan all:
+ *   node scripts/validate-structure.ts
  */
 
 import { access, constants, readFile, readdir, stat } from "node:fs/promises";

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -13,7 +13,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { basename, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
-import Ajv from "ajv/dist/2020.js";
+import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { parse as parseYaml } from "yaml";
 import validator from "validator";
 
@@ -27,12 +27,12 @@ const metadataSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
 const ajv = new Ajv({ allErrors: true });
 const validateMetadataSchema = ajv.compile(metadataSchema);
 
-function error(gapName, message) {
+function error(gapName: string, message: string) {
   console.error(`${gapName}: ${message}`);
   process.exit(1);
 }
 
-function validateDirectoryNaming(dirPath) {
+function validateDirectoryNaming(dirPath: string) {
   const dirName = basename(dirPath);
 
   // Special case: GAP-0 is allowed
@@ -51,14 +51,14 @@ function validateDirectoryNaming(dirPath) {
   return dirName;
 }
 
-function validateReadmeExists(dirPath, gapName) {
+function validateReadmeExists(dirPath: string, gapName: string) {
   const readmePath = join(dirPath, "README.md");
   if (!existsSync(readmePath)) {
     error(gapName, "No README.md file found");
   }
 }
 
-function validateMetadata(dirPath, gapName) {
+function validateMetadata(dirPath: string, gapName: string) {
   const metadataPath = join(dirPath, "metadata.yml");
 
   if (!existsSync(metadataPath)) {
@@ -69,30 +69,34 @@ function validateMetadata(dirPath, gapName) {
   try {
     content = readFileSync(metadataPath, "utf8");
   } catch (err) {
-    error(gapName, `Failed to read metadata.yml: ${err.message}`);
+    error(gapName, `Failed to read metadata.yml: ${String(err)}`);
+    return;
   }
 
   let metadata;
   try {
     metadata = parseYaml(content);
   } catch (err) {
-    error(gapName, `Invalid YAML in metadata.yml: ${err.message}`);
+    error(gapName, `Invalid YAML in metadata.yml: ${String(err)}`);
+    return;
   }
 
   if (typeof metadata !== "object") {
     error(gapName, "metadata.yml must contain a valid YAML object");
+    return;
   }
 
   // Validate against JSON Schema
   const valid = validateMetadataSchema(metadata);
   if (!valid) {
-    const errors = validateMetadataSchema.errors
-      .map((err) => {
+    const errors = validateMetadataSchema
+      .errors!.map((err) => {
         const prefix = err.instancePath ? `${err.instancePath}: ` : "";
         return `${prefix}${err.message}`;
       })
       .join("\n");
     error(gapName, `metadata.yml validation failed:\n\n${errors}`);
+    return;
   }
 
   // Validate authors have valid email
@@ -114,7 +118,7 @@ function validateMetadata(dirPath, gapName) {
   }
 }
 
-function validateAllowedFiles(dirPath, gapName) {
+function validateAllowedFiles(dirPath: string, gapName: string) {
   for (const entry of readdirSync(dirPath)) {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed: "${entry}".`);
@@ -132,7 +136,11 @@ function validateAllowedFiles(dirPath, gapName) {
       continue;
     }
 
-    if (entry === "metadata.yml" || entry === "metadata.json" || entry.endsWith(".md")) {
+    if (
+      entry === "metadata.yml" ||
+      entry === "metadata.json" ||
+      entry.endsWith(".md")
+    ) {
       continue;
     }
 
@@ -140,7 +148,7 @@ function validateAllowedFiles(dirPath, gapName) {
   }
 }
 
-function validateVersionsDir(dirPath, gapName) {
+function validateVersionsDir(dirPath: string, gapName: string) {
   for (const entry of readdirSync(dirPath)) {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed in versions/: "${entry}".`);
@@ -153,7 +161,10 @@ function validateVersionsDir(dirPath, gapName) {
     }
 
     if (!/^\d{4}-\d{2}\.(md|yml)$/.test(entry)) {
-      error(gapName, `Unexpected file in versions/: "${entry}". Only YYYY-MM.md and YYYY-MM.yml are allowed.`);
+      error(
+        gapName,
+        `Unexpected file in versions/: "${entry}". Only YYYY-MM.md and YYYY-MM.yml are allowed.`,
+      );
     }
   }
 }

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -10,7 +10,7 @@
  */
 
 import { access, constants, readFile, readdir, stat } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { basename, join, resolve } from "node:path";
 import { parseArgs } from "node:util";
 import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { parse as parseYaml } from "yaml";
@@ -25,10 +25,11 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
-const __dirname = import.meta.dirname;
+const ROOT = resolve(import.meta.dirname, "..");
+const GAPS_DIR = join(ROOT, "gaps");
 
 // Load JSON Schema from root directory
-const schemaPath = join(__dirname, "..", "metadata.schema.json");
+const schemaPath = join(ROOT, "metadata.schema.json");
 const metadataSchema = JSON.parse(await readFile(schemaPath, "utf8"));
 
 // Set up ajv with JSON Schema
@@ -41,7 +42,7 @@ function error(gapName: string, message: string) {
   errors[gapName].push(message);
 }
 
-function validateDirectoryNaming(dirPath: string) {
+function validateDirectoryNaming(dirPath: string): string | null {
   const dirName = basename(dirPath);
 
   // Special case: GAP-0 is allowed
@@ -55,6 +56,7 @@ function validateDirectoryNaming(dirPath: string) {
       dirName,
       `Invalid directory name format. Expected GAP-N (e.g. GAP-10, GAP-123)`,
     );
+    return null;
   }
 
   return dirName;
@@ -72,6 +74,7 @@ async function validateMetadata(dirPath: string, gapName: string) {
 
   if (!(await exists(metadataPath))) {
     error(gapName, "No metadata.yml file found");
+    return;
   }
 
   let content;
@@ -143,18 +146,15 @@ async function validateAllowedFiles(dirPath: string, gapName: string) {
       } else {
         error(gapName, `Unexpected directory "${entry}".`);
       }
-      return;
-    }
-
-    if (
+    } else if (
       entry === "metadata.yml" ||
       entry === "metadata.json" ||
       entry.endsWith(".md")
     ) {
-      return;
+      // Allowed
+    } else {
+      error(gapName, `Unexpected file "${entry}".`);
     }
-
-    error(gapName, `Unexpected file "${entry}".`);
   });
   await Promise.all(promises);
 }
@@ -164,19 +164,15 @@ async function validateVersionsDir(dirPath: string, gapName: string) {
   const promises = entries.map(async (entry) => {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed in versions/: "${entry}".`);
-      return;
-    }
-
-    if ((await stat(join(dirPath, entry))).isDirectory()) {
+    } else if ((await stat(join(dirPath, entry))).isDirectory()) {
       error(gapName, `Unexpected directory in versions/: "${entry}".`);
-      return;
-    }
-
-    if (!/^\d{4}-\d{2}\.(md|yml)$/.test(entry)) {
+    } else if (!/^\d{4}-\d{2}\.(md|yml)$/.test(entry)) {
       error(
         gapName,
         `Unexpected file in versions/: "${entry}". Only YYYY-MM.md and YYYY-MM.yml are allowed.`,
       );
+    } else {
+      // Passes all the checks
     }
   });
   await Promise.all(promises);
@@ -185,38 +181,61 @@ async function validateVersionsDir(dirPath: string, gapName: string) {
 async function main() {
   const { positionals } = parseArgs({ allowPositionals: true, strict: true });
 
-  if (positionals.length !== 1) {
+  const gapsToCheck: string[] = [];
+
+  if (positionals.length > 1) {
     console.error("Usage: ./scripts/validate-structure.ts <gap-directory>");
     process.exit(1);
+  } else if (positionals.length === 1) {
+    gapsToCheck.push(positionals[0]);
+  } else {
+    const gaps = await readdir(GAPS_DIR);
+    await Promise.all(
+      gaps.map(async (filename) => {
+        if (filename.startsWith(".")) return;
+        const fullPath = join(GAPS_DIR, filename);
+        const stats = await stat(fullPath);
+        if (stats.isDirectory()) {
+          gapsToCheck.push(fullPath);
+        }
+      }),
+    );
   }
 
-  const dirPath = positionals[0];
+  await Promise.all(
+    gapsToCheck.map(async (dirPath) => {
+      // Validate directory naming
+      const gapName = validateDirectoryNaming(dirPath);
+      if (gapName == null) return;
 
-  if (!(await exists(dirPath))) {
-    console.error(`Directory does not exist: ${dirPath}`);
-    process.exit(1);
-  }
+      let stats;
+      try {
+        stats = await stat(dirPath);
+      } catch (e) {
+        error(gapName, `Directory ${dirPath} does not exist? ${e}`);
+        return;
+      }
 
-  if (!(await stat(dirPath)).isDirectory()) {
-    console.error(`Not a directory: ${dirPath}`);
-    process.exit(1);
-  }
+      if (!stats.isDirectory()) {
+        error(gapName, `Not a directory: ${dirPath}`);
+      } else {
+        await Promise.all([
+          // Validate only allowed files are present
+          validateAllowedFiles(dirPath, gapName),
 
-  // Validate directory naming
-  const gapName = validateDirectoryNaming(dirPath);
+          // Validate README.md exists
+          validateReadmeExists(dirPath, gapName),
 
-  // Validate only allowed files are present
-  await validateAllowedFiles(dirPath, gapName);
-
-  // Validate README.md exists
-  await validateReadmeExists(dirPath, gapName);
-
-  // Validate metadata.yml
-  await validateMetadata(dirPath, gapName);
+          // Validate metadata.yml
+          validateMetadata(dirPath, gapName),
+        ]);
+      }
+    }),
+  );
 
   const badGaps = Object.keys(errors);
   if (badGaps.length > 0) {
-    process.exitCode = 1;
+    process.exitCode = 2;
     badGaps.sort(); // This is lexicographic... Not ideal but I'm too lazy to parse it.
     for (const gapName of badGaps) {
       console.error(`# ${gapName}`);

--- a/scripts/validate-structure.ts
+++ b/scripts/validate-structure.ts
@@ -9,7 +9,7 @@
  *   find ./gaps -maxdepth 1 -type d -name 'GAP-*' | xargs -I{} node scripts/validate-structure.ts {}
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { access, constants, readFile, readdir, stat } from "node:fs/promises";
 import { basename, join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
@@ -17,11 +17,20 @@ import { Ajv2020 as Ajv } from "ajv/dist/2020.js";
 import { parse as parseYaml } from "yaml";
 import validator from "validator";
 
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Load JSON Schema from root directory
 const schemaPath = join(__dirname, "..", "metadata.schema.json");
-const metadataSchema = JSON.parse(readFileSync(schemaPath, "utf8"));
+const metadataSchema = JSON.parse(await readFile(schemaPath, "utf8"));
 
 // Set up ajv with JSON Schema
 const ajv = new Ajv({ allErrors: true });
@@ -51,23 +60,23 @@ function validateDirectoryNaming(dirPath: string) {
   return dirName;
 }
 
-function validateReadmeExists(dirPath: string, gapName: string) {
+async function validateReadmeExists(dirPath: string, gapName: string) {
   const readmePath = join(dirPath, "README.md");
-  if (!existsSync(readmePath)) {
+  if (!(await exists(readmePath))) {
     error(gapName, "No README.md file found");
   }
 }
 
-function validateMetadata(dirPath: string, gapName: string) {
+async function validateMetadata(dirPath: string, gapName: string) {
   const metadataPath = join(dirPath, "metadata.yml");
 
-  if (!existsSync(metadataPath)) {
+  if (!(await exists(metadataPath))) {
     error(gapName, "No metadata.yml file found");
   }
 
   let content;
   try {
-    content = readFileSync(metadataPath, "utf8");
+    content = await readFile(metadataPath, "utf8");
   } catch (err) {
     error(gapName, `Failed to read metadata.yml: ${String(err)}`);
     return;
@@ -118,8 +127,8 @@ function validateMetadata(dirPath: string, gapName: string) {
   }
 }
 
-function validateAllowedFiles(dirPath: string, gapName: string) {
-  for (const entry of readdirSync(dirPath)) {
+async function validateAllowedFiles(dirPath: string, gapName: string) {
+  for (const entry of await readdir(dirPath)) {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed: "${entry}".`);
       continue;
@@ -127,9 +136,9 @@ function validateAllowedFiles(dirPath: string, gapName: string) {
 
     const fullPath = join(dirPath, entry);
 
-    if (statSync(fullPath).isDirectory()) {
+    if ((await stat(fullPath)).isDirectory()) {
       if (entry === "versions") {
-        validateVersionsDir(fullPath, gapName);
+        await validateVersionsDir(fullPath, gapName);
       } else {
         error(gapName, `Unexpected directory "${entry}".`);
       }
@@ -148,14 +157,14 @@ function validateAllowedFiles(dirPath: string, gapName: string) {
   }
 }
 
-function validateVersionsDir(dirPath: string, gapName: string) {
-  for (const entry of readdirSync(dirPath)) {
+async function validateVersionsDir(dirPath: string, gapName: string) {
+  for (const entry of await readdir(dirPath)) {
     if (entry.startsWith(".")) {
       error(gapName, `Dotfiles are not allowed in versions/: "${entry}".`);
       continue;
     }
 
-    if (statSync(join(dirPath, entry)).isDirectory()) {
+    if ((await stat(join(dirPath, entry))).isDirectory()) {
       error(gapName, `Unexpected directory in versions/: "${entry}".`);
       continue;
     }
@@ -169,7 +178,7 @@ function validateVersionsDir(dirPath: string, gapName: string) {
   }
 }
 
-function main() {
+async function main() {
   const { positionals } = parseArgs({ allowPositionals: true, strict: true });
 
   if (positionals.length !== 1) {
@@ -179,12 +188,12 @@ function main() {
 
   const dirPath = positionals[0];
 
-  if (!existsSync(dirPath)) {
+  if (!(await exists(dirPath))) {
     console.error(`Directory does not exist: ${dirPath}`);
     process.exit(1);
   }
 
-  if (!statSync(dirPath).isDirectory()) {
+  if (!(await stat(dirPath)).isDirectory()) {
     console.error(`Not a directory: ${dirPath}`);
     process.exit(1);
   }
@@ -193,13 +202,13 @@ function main() {
   const gapName = validateDirectoryNaming(dirPath);
 
   // Validate only allowed files are present
-  validateAllowedFiles(dirPath, gapName);
+  await validateAllowedFiles(dirPath, gapName);
 
   // Validate README.md exists
-  validateReadmeExists(dirPath, gapName);
+  await validateReadmeExists(dirPath, gapName);
 
   // Validate metadata.yml
-  validateMetadata(dirPath, gapName);
+  await validateMetadata(dirPath, gapName);
 }
 
-main();
+await main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "@tsconfig/node24/tsconfig.json",
+    "@tsconfig/node-ts/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
Adds a file allowlist check to `validate-structure.js` — GAP directories may now only contain `*.md` files and `metadata.yml`. Rejects unexpected files or subdirectories with a message pointing contributors to @graphql/gaps-editors.

Motivation: prevent files like `.nvmrc` from being merged that could inadvertently affect developer environments.