### PR TITLE
Sort GAP directories numerically instead of lexicographically

### DIFF
--- a/scripts/build-website.js
+++ b/scripts/build-website.js
@@ -39,7 +39,7 @@ async function findGapDirs(parent) {
   return (await readdir(parent, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory() && entry.name.startsWith("GAP-"))
     .map((entry) => entry.name)
-    .sort()
+    .sort((a, b) => parseInt(a.split("-")[1], 10) - parseInt(b.split("-")[1], 10))
     .map((name) => join(parent, name));
 }
 

--- a/scripts/sync-codeowners.js
+++ b/scripts/sync-codeowners.js
@@ -16,7 +16,7 @@ async function getGapDirs() {
 
 async function main() {
   const dirs = await getGapDirs();
-  dirs.sort();
+  dirs.sort((a, b) => parseInt(a.name.split("-")[1], 10) - parseInt(b.name.split("-")[1], 10));
 
   const lines = await Promise.all(
     dirs.map(async (dir) => {


### PR DESCRIPTION
GAPs are currently sorted on https://gaps.graphql.org/ lexicographically (GAP-10, GAP-13, GAP-33, GAP-7)

We should instead sort alphanumerically (GAP-7, GAP-10, GAP-13, GAP-33)

Considering this a bugfix and merging.