### PR TITLE
Harden /merge workflow security

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -13,16 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.event.issue.pull_request &&
-      github.event.comment.body == '/merge'
+      github.event.comment.body == '/merge' &&
+      github.event.comment.author_association != 'NONE'
     steps:
       - uses: actions/checkout@v6
-      - run: npm install js-yaml
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - run: npm ci
 
       - name: Verify actor is authorized
         uses: actions/github-script@v9
         with:
           script: |
-            const verifyMerge = require('./scripts/verify-merge.js');
+            const { default: verifyMerge } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/verify-merge.js`
+            );
             await verifyMerge({ github, context });
 
       - name: Merge PR
@@ -30,4 +40,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh pr merge "$PR_NUMBER" --squash --auto
+          gh pr merge "$PR_NUMBER" --squash

--- a/scripts/verify-merge.js
+++ b/scripts/verify-merge.js
@@ -1,32 +1,70 @@
-const fs = require("fs");
-const yaml = require("js-yaml");
+import { readFile } from "fs/promises";
+import path from "path";
+import { parse as parseYaml } from "yaml";
 
-module.exports = async ({ github, context }) => {
+export default async ({ github, context }) => {
   const actor = context.payload.comment.user.login;
   const prNumber = context.issue.number;
 
-  const { data: files } = await github.rest.pulls.listFiles({
-    ...context.repo,
-    pull_number: prNumber,
-  });
+  const [{ data: pr }, { data: files }] = await Promise.all([
+    github.rest.pulls.get({
+      ...context.repo,
+      pull_number: prNumber,
+    }),
+    github.rest.pulls.listFiles({
+      ...context.repo,
+      pull_number: prNumber,
+      per_page: 100,
+    }),
+  ]);
 
-  const gapDirs = files
-    .map((f) => f.filename)
-    .map((p) => p.split("/").slice(0, 2).join("/"));
-
-  const gapsChanged = [...new Set(gapDirs)];
-
-  if (gapsChanged.length !== 1 || !gapsChanged[0].match(/^gaps\/GAP-\d+$/)) {
-    throw new Error("You can only run /merge for PRs that touch exactly one GAP directory and nothing else.");
+  if (pr.mergeable === false) {
+    throw new Error(
+      "PR is not in a mergeable state. Resolve conflicts and try again.",
+    );
   }
 
-  const metadata = yaml.load(fs.readFileSync(`${gapsChanged[0]}/metadata.yml`, "utf8"));
+  const gapDirSet = new Set();
+
+  for (const f of files) {
+    const normalized = path.normalize(f.filename);
+    if (normalized !== f.filename || normalized.startsWith("..")) {
+      throw new Error(
+        `File path "${f.filename}" contains path traversal or is not normalized.`,
+      );
+    }
+    gapDirSet.add(f.filename.split("/").slice(0, 2).join("/"));
+  }
+
+  const gapsChanged = [...gapDirSet];
+
+  if (gapsChanged.length !== 1 || !gapsChanged[0].match(/^gaps\/GAP-\d+$/)) {
+    throw new Error(
+      "You can only run /merge for PRs that touch exactly one GAP directory and nothing else.",
+    );
+  }
+
+  const gapDir = gapsChanged[0];
+
+  for (const f of files) {
+    if (!f.filename.startsWith(`${gapDir}/`)) {
+      throw new Error(
+        `File "${f.filename}" is outside the expected GAP directory (${gapDir}).`,
+      );
+    }
+  }
+
+  const metadata = parseYaml(
+    await readFile(`${gapDir}/metadata.yml`, "utf8"),
+  );
   const authorizedMergers = new Set([
-    ...metadata.authors.map(author => author.githubUsername.replace(/^@/, '')),
-    metadata.sponsor.replace(/^@/, ''),
+    ...metadata.authors.map((author) =>
+      author.githubUsername.replace(/^@/, ""),
+    ),
+    metadata.sponsor.replace(/^@/, ""),
   ]);
 
   if (!authorizedMergers.has(actor)) {
-    throw new Error(`${actor} is not authorized to merge ${gapsChanged[0]}.`);
+    throw new Error(`${actor} is not authorized to merge ${gapDir}.`);
   }
 };


### PR DESCRIPTION
## Summary

Security hardening for the `/merge` workflow introduced in #32.

### Changes

- **Remove `--auto` flag** — `gh pr merge --squash --auto` enables auto-merge, which means the actual merge happens later (when checks pass). Between the `/merge` authorization check and the eventual merge, a PR author could force-push new commits that touch files outside their GAP directory (e.g. `.github/workflows/`). By merging immediately (without `--auto`), the authorization check and merge are atomic within the same workflow run.

- **Path traversal defense** — Validate that all PR file paths are normalized (no `..` components) and explicitly verify every file lives under the single authorized GAP directory. Git itself prevents `..` in tree paths, so this is defense-in-depth rather than an active exploit, but it guards against any future API behavior changes.

- **Mergeable state check** — Verify `pr.mergeable` before attempting merge to fail fast with a clear error message.

- **Filter out `NONE` association commenters** — Skip workflow runs for commenters with no relationship to the repo. The authorization check would reject them anyway, but this avoids burning Actions minutes on spam.

- **Use `npm ci` with lockfile instead of ad-hoc `npm install js-yaml`** — The original workflow installed `js-yaml` without version pinning at runtime, which is a supply-chain risk. The repo already has the `yaml` package in `devDependencies` with a lockfile, so we use that instead.

- **Convert to ESM** — The project is `"type": "module"` and all other scripts use ESM. Aligns `verify-merge.js` with the rest of the codebase.

## Security model after this change

1. `issue_comment` triggers run the workflow from the default branch — an attacker cannot modify the verification logic via their PR
2. Authorization is checked against `metadata.yml` on `main` (the checkout is the default branch)
3. Merge happens immediately in the same step, so there's no window for the PR to change between check and merge
4. Branch protection rules still apply (required checks must pass before `gh pr merge` succeeds)

## Test plan

- [ ] Comment `/merge` on a PR touching a single GAP dir as an authorized author → merges
- [ ] Comment `/merge` as an unauthorized user → rejects with error
- [ ] Comment `/merge` on a PR touching multiple GAP dirs → rejects
- [ ] Comment `/merge` on a PR touching files outside `gaps/` → rejects

🤖 Generated with [Claude Code](https://claude.com/claude-code)