### PR TITLE
Use GitHub shorthand for discussion links

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -28,8 +28,11 @@ jobs:
       - name: Build GAP website
         run: npm run build
 
+      - name: Save PR metadata
+        run: echo "${{ github.event.pull_request.number }}" > _site/.pr-number
+
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: preview-build
           path: _site

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,36 @@
+name: Build Preview
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build GAP website
+        run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-build
+          path: _site
+          retention-days: 1

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ["Build Preview"]
+    types: [completed]
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy preview to Cloudflare
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: _site
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy _site --project-name=gaps --branch=pr-${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   deployments: write
 
 jobs:
@@ -17,16 +18,20 @@ jobs:
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: preview-build
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: _site
 
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat _site/.pr-number)" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy _site --project-name=gaps --branch=pr-${{ github.event.workflow_run.pull_requests[0].number }}
+          command: pages deploy _site --project-name=gaps --branch=pr-${{ steps.pr.outputs.number }}

--- a/gaps/GAP-10/metadata.yml
+++ b/gaps/GAP-10/metadata.yml
@@ -13,4 +13,4 @@ authors:
     email: "me@michaelrebello.com"
     githubUsername: "@rebello95"
 sponsor: "@magicmark"
-discussion: "https://github.com/graphql/gaps/pull/10"
+discussion: "graphql/gaps#10"

--- a/gaps/GAP-13/metadata.yml
+++ b/gaps/GAP-13/metadata.yml
@@ -10,4 +10,4 @@ authors:
     email: "code@benjiegillam.com"
     githubUsername: "@benjie"
 sponsor: "@benjie"
-discussion: "https://github.com/graphql/gaps/pull/13"
+discussion: "graphql/gaps#13"

--- a/gaps/GAP-33/metadata.yml
+++ b/gaps/GAP-33/metadata.yml
@@ -9,4 +9,4 @@ authors:
     email: "mahoney.mattj@gmail.com"
     githubUsername: "@mjmahone"
 sponsor: "@magicmark"
-discussion: "https://github.com/graphql/gaps/pull/33"
+discussion: "graphql/gaps#33"

--- a/gaps/GAP-7/metadata.yml
+++ b/gaps/GAP-7/metadata.yml
@@ -10,4 +10,4 @@ authors:
     email: "markl@yelp.com"
     githubUsername: "@magicmark"
 sponsor: "@magicmark"
-discussion: "https://github.com/graphql/gaps/pull/7"
+discussion: "graphql/gaps#7"

--- a/scripts/build-website.js
+++ b/scripts/build-website.js
@@ -28,6 +28,14 @@ import { parse as parseYaml } from "yaml";
 
 const require = createRequire(import.meta.url);
 const specMarkdown = require("@mlarah/spec-md");
+
+function discussionUrl(discussion) {
+  const match = discussion.match(/^([^/]+\/[^#]+)#(\d+)$/);
+  if (match) {
+    return `https://github.com/${match[1]}/pull/${match[2]}`;
+  }
+  return discussion;
+}
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(__dirname, "..");
 const websiteDir = join(rootDir, "website");
@@ -151,7 +159,8 @@ async function renderGapMeta(gap) {
   if (gap.discussion) {
     items.push({
       label: "Discussion",
-      href: gap.discussion,
+      href: discussionUrl(gap.discussion),
+      value: gap.discussion,
     });
   }
 
@@ -281,7 +290,7 @@ async function buildGap(gapDir, outDir) {
           [gapName]: gapMetadata.title,
           Version: document.label,
           Authors: gapMetadata.authors.map((a) => a.name).join(", "),
-          Discussion: gapMetadata.discussion,
+          Discussion: discussionUrl(gapMetadata.discussion),
         },
       });
 

--- a/scripts/validate-structure.js
+++ b/scripts/validate-structure.js
@@ -105,11 +105,14 @@ function validateMetadata(dirPath, gapName) {
     }
   }
 
-  // Validate discussion is a valid URL
-  if (!validator.isURL(metadata.discussion)) {
+  // Validate discussion is a valid URL or GitHub shorthand (owner/repo#number)
+  const isGitHubShorthand = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+#\d+$/.test(
+    metadata.discussion,
+  );
+  if (!isGitHubShorthand && !validator.isURL(metadata.discussion)) {
     error(
       gapName,
-      `metadata.yml discussion must be a valid URL (got "${metadata.discussion}")`,
+      `metadata.yml discussion must be a valid URL or GitHub shorthand e.g. "graphql/gaps#10" (got "${metadata.discussion}")`,
     );
   }
 }

--- a/website/templates/gap-meta.html
+++ b/website/templates/gap-meta.html
@@ -4,7 +4,7 @@
     <dt>{{label}}</dt>
     <dd>
       {{#if href}}
-      <a href="{{href}}">Open discussion</a>
+      <a href="{{href}}">{{#if value}}{{value}}{{else}}Open discussion{{/if}}</a>
       {{else}} {{value}} {{/if}}
     </dd>
   </div>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "gaps",
+  "compatibility_date": "2026-05-21",
+  "assets": {
+    "directory": "./_site"
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
+  "$schema": "node_modules/wrangler/config-schema.json",
   "name": "gaps",
-  "compatibility_date": "2026-05-21",
+  "compatibility_date": "2026-05-23",
   "assets": {
     "directory": "./_site"
   }


### PR DESCRIPTION
Use GitHub shorthand notation (`graphql/gaps#10`) instead of full URLs (`https://github.com/graphql/gaps/pull/10`) for the `discussion` field in metadata.yml files. The validator and build scripts are updated to handle both formats.

_**Draft PR**: This PR was sent by Claude and may not have yet been reviewed by markl._