### PR TITLE
[GAP-10] Specify that clients should populate error `path` from `__path__`

### DIFF
--- a/gaps/GAP-10/DRAFT.md
+++ b/gaps/GAP-10/DRAFT.md
@@ -345,7 +345,9 @@ list value directly:
 This is valid for both operation-level and field-level `@mock` directives.
 
 The client must append the contents of {"errors"} to the response's {"errors"}
-array.
+array. For each of these error objects, the client should populate the {"path"} field at
+runtime using the response path derived from {"__path__"}, ensuring that error
+paths correctly reflect the field's position in the response.
 
 #### extensions
 


### PR DESCRIPTION
Adds guidance that mock error objects should have their `path` field populated at runtime using the response path derived from `__path__`, ensuring errors correctly reflect their position in the response.

Addresses https://github.com/graphql/gaps/pull/46#discussion_r3327977047