### PR TITLE
Address Benjie's review feedback

### DIFF
--- a/.github/scripts/hide-old-deploy-comments.mjs
+++ b/.github/scripts/hide-old-deploy-comments.mjs
@@ -1,0 +1,27 @@
+// Minimizes previous deploy-preview comments so only the latest is visible.
+// Called from preview-deploy.yml via actions/github-script.
+
+export default async function run({ github, context, prNumber }) {
+  const { data: comments } = await github.rest.issues.listComments({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: prNumber,
+  });
+
+  await Promise.all(
+    comments
+      .filter((c) => c.body.includes("<!-- deploy-preview -->"))
+      .map((c) =>
+        github.graphql(
+          `
+          mutation($id: ID!) {
+            minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+              minimizedComment { isMinimized }
+            }
+          }
+        `,
+          { id: c.node_id }
+        )
+      )
+  );
+}

--- a/.github/scripts/hide-old-deploy-comments.mjs
+++ b/.github/scripts/hide-old-deploy-comments.mjs
@@ -2,7 +2,7 @@
 // Called from preview-deploy.yml via actions/github-script.
 
 export default async function run({ github, context, prNumber }) {
-  const { data: comments } = await github.rest.issues.listComments({
+  const comments = await github.paginate(github.rest.issues.listComments, {
     owner: context.repo.owner,
     repo: context.repo.repo,
     issue_number: prNumber,
@@ -10,7 +10,11 @@ export default async function run({ github, context, prNumber }) {
 
   await Promise.all(
     comments
-      .filter((c) => c.body.includes("<!-- deploy-preview -->"))
+      .filter(
+        (c) =>
+          c.user.login === "github-actions[bot]" &&
+          c.body.includes("<!-- deploy-preview -->")
+      )
       .map((c) =>
         github.graphql(
           `

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -20,9 +20,14 @@ jobs:
       - name: Checkout wrangler config
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: main
           sparse-checkout: |
             wrangler.jsonc
+            .github/scripts
 
+      # Security: actions/download-artifact handles zip extraction safely
+      # (immune to zip-slip), and the artifact only contains static HTML/CSS/JS
+      # built by the unprivileged preview-build workflow.
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -45,34 +50,23 @@ jobs:
           fi
           echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
 
+      # Security: Wrangler is configured for static asset serving only (see
+      # wrangler.jsonc). The uploaded content is pre-built HTML/CSS/JS with no
+      # server-side execution capability.
       - name: Deploy preview to Cloudflare Workers
         id: deploy
         uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --preview-alias "pr-${{ steps.pr.outputs.number }}" --message "PR #${{ steps.pr.outputs.number }} preview"
+          command: versions upload --preview-alias "pr-${{ steps.pr.outputs.number }}" --message "PR #${{ steps.pr.outputs.number }} preview (${{ github.event.workflow_run.head_sha }})"
 
       - name: Hide old deploy preview comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.number }}
-            });
-            await Promise.all(
-              comments
-                .filter(c => c.body.includes('<!-- deploy-preview -->'))
-                .map(c => github.graphql(`
-                  mutation($id: ID!) {
-                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
-                      minimizedComment { isMinimized }
-                    }
-                  }
-                `, { id: c.node_id }))
-            );
+            const { default: run } = await import('${{ github.workspace }}/.github/scripts/hide-old-deploy-comments.mjs');
+            await run({ github, context, prNumber: ${{ steps.pr.outputs.number }} });
 
       - name: Comment on PR (success)
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -59,7 +59,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: versions upload --preview-alias "pr-${{ steps.pr.outputs.number }}" --message "PR #${{ steps.pr.outputs.number }} preview (${{ github.event.workflow_run.head_sha }})"
+          command: >-
+            versions upload
+              --no-bundle
+              --preview-alias "pr-${{ steps.pr.outputs.number }}"
+              --message "PR #${{ steps.pr.outputs.number }} preview (${{ github.event.workflow_run.head_sha }})"
 
       - name: Hide old deploy preview comments
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
Addresses the review comments from benjie on #40:

1. **`ref: main`** on checkout step — makes it explicit we're pulling trusted config from main, not from the PR branch
2. **Commit hash in deploy message** — adds `(${{ github.event.workflow_run.head_sha }})` for traceability
3. **Extract inline JS** — moves the hide-old-comments logic to `.github/scripts/hide-old-deploy-comments.mjs` (also adds `.github/scripts` to sparse-checkout so it's available at runtime)
4. **Security: outside bounds zip extraction** — documents that `actions/download-artifact` handles extraction safely
5. **Security: static-only wrangler** — documents that wrangler is configured for static asset serving only

All changes verified end-to-end on [magicmark/gaps-website-test-1](https://github.com/magicmark/gaps-website-test-1) with both fork and non-fork PRs deploying successfully to Cloudflare Workers.