### PR TITLE
CI: validate that new GAP metadata id matches PR number

### DIFF
--- a/.github/workflows/validate-new-gap-number.yml
+++ b/.github/workflows/validate-new-gap-number.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/validate-new-gap-number.yml
+++ b/.github/workflows/validate-new-gap-number.yml
@@ -1,19 +1,19 @@
-name: Validate GAP Structure
+name: Validate new GAP number
 
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 jobs:
-  validate:
-    name: Validate GAP directories
+  validate-gap-number:
+    name: Validate new GAP id matches PR number
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -24,5 +24,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Validate GAP structure
-        run: npm run test:structure
+      - name: Validate new GAP id matches PR number
+        run: node scripts/validate-new-gap-number.js
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-new-gap-number.yml
+++ b/.github/workflows/validate-new-gap-number.yml
@@ -25,6 +25,4 @@ jobs:
         run: npm ci
 
       - name: Validate new GAP id matches PR number
-        run: node scripts/validate-new-gap-number.js
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/validate-new-gap-number.js --pr-number ${{ github.event.pull_request.number }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -26,3 +28,25 @@ jobs:
 
       - name: Validate GAP structure
         run: npm run test:structure
+
+      - name: Validate new GAP id matches PR number
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Find metadata.yml files newly added in this PR
+          new_metadata_files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- 'gaps/*/metadata.yml')
+
+          if [ -z "$new_metadata_files" ]; then
+            echo "No new metadata.yml files added in this PR."
+            exit 0
+          fi
+
+          for file in $new_metadata_files; do
+            id=$(grep -m1 '^id:' "$file" | awk '{print $2}')
+            if [ "$id" != "$PR_NUMBER" ]; then
+              echo "::error file=${file}::metadata.yml 'id' field is ${id}, but must match the PR number (${PR_NUMBER}). See CONTRIBUTING.md."
+              exit 1
+            fi
+            echo "✓ ${file}: id ${id} matches PR #${PR_NUMBER}"
+          done

--- a/scripts/validate-new-gap-number.js
+++ b/scripts/validate-new-gap-number.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
 /**
- * Validates that newly added metadata.yml files have an `id` field matching
- * the PR number, per CONTRIBUTING.md.
+ * Validates that newly added GAP directories and their metadata.yml `id` field
+ * both match the PR number, per CONTRIBUTING.md.
  *
  * Usage: PR_NUMBER=123 node scripts/validate-new-gap-number.js
  */
 
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { dirname, basename } from "node:path";
 import { parse as parseYaml } from "yaml";
 
 const prNumber = process.env.PR_NUMBER;
@@ -34,6 +35,18 @@ if (newMetadataFiles.length === 0) {
 let failed = false;
 
 for (const file of newMetadataFiles) {
+  const gapDir = basename(dirname(file));
+  const expectedDir = `GAP-${prNumber}`;
+
+  if (gapDir !== expectedDir) {
+    console.error(
+      `::error file=${file}::GAP directory is ${gapDir}, but must be ${expectedDir} to match the PR number. See CONTRIBUTING.md.`,
+    );
+    failed = true;
+  } else {
+    console.log(`✓ ${file}: directory ${gapDir} matches PR #${prNumber}`);
+  }
+
   const content = readFileSync(file, "utf8");
   const metadata = parseYaml(content);
   const id = String(metadata.id);

--- a/scripts/validate-new-gap-number.js
+++ b/scripts/validate-new-gap-number.js
@@ -22,11 +22,6 @@ const { values } = parseArgs({
 
 const prNumber = values["pr-number"];
 
-if (!prNumber) {
-  console.error("Usage: node scripts/validate-new-gap-number.js --pr-number <number>");
-  process.exit(1);
-}
-
 const newMetadataFiles = execSync(
   "git diff --name-only --diff-filter=A origin/main...HEAD -- 'gaps/*/metadata.yml'",
   { encoding: "utf8" },

--- a/scripts/validate-new-gap-number.js
+++ b/scripts/validate-new-gap-number.js
@@ -4,18 +4,26 @@
  * Validates that newly added GAP directories and their metadata.yml `id` field
  * both match the PR number, per CONTRIBUTING.md.
  *
- * Usage: PR_NUMBER=123 node scripts/validate-new-gap-number.js
+ * Usage: node scripts/validate-new-gap-number.js --pr-number 123
  */
 
 import { readFileSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { dirname, basename } from "node:path";
+import { parseArgs } from "node:util";
 import { parse as parseYaml } from "yaml";
 
-const prNumber = process.env.PR_NUMBER;
+const { values } = parseArgs({
+  options: {
+    "pr-number": { type: "string" },
+  },
+  strict: true,
+});
+
+const prNumber = values["pr-number"];
 
 if (!prNumber) {
-  console.error("PR_NUMBER environment variable is required.");
+  console.error("Usage: node scripts/validate-new-gap-number.js --pr-number <number>");
   process.exit(1);
 }
 

--- a/scripts/validate-new-gap-number.js
+++ b/scripts/validate-new-gap-number.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/**
+ * Validates that newly added metadata.yml files have an `id` field matching
+ * the PR number, per CONTRIBUTING.md.
+ *
+ * Usage: PR_NUMBER=123 node scripts/validate-new-gap-number.js
+ */
+
+import { readFileSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { parse as parseYaml } from "yaml";
+
+const prNumber = process.env.PR_NUMBER;
+
+if (!prNumber) {
+  console.error("PR_NUMBER environment variable is required.");
+  process.exit(1);
+}
+
+const newMetadataFiles = execSync(
+  "git diff --name-only --diff-filter=A origin/main...HEAD -- 'gaps/*/metadata.yml'",
+  { encoding: "utf8" },
+)
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+
+if (newMetadataFiles.length === 0) {
+  console.log("No new metadata.yml files added in this PR.");
+  process.exit(0);
+}
+
+let failed = false;
+
+for (const file of newMetadataFiles) {
+  const content = readFileSync(file, "utf8");
+  const metadata = parseYaml(content);
+  const id = String(metadata.id);
+
+  if (id !== prNumber) {
+    console.error(
+      `::error file=${file}::metadata.yml 'id' field is ${id}, but must match the PR number (${prNumber}). See CONTRIBUTING.md.`,
+    );
+    failed = true;
+  } else {
+    console.log(`✓ ${file}: id ${id} matches PR #${prNumber}`);
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
Adds a dedicated workflow (`validate-new-gap-number.yml`) to that new GAP `metadata.yml` files have their `id` field set to the PR number, per CONTRIBUTING.md.

Only runs on pull requests that add a new GAP.

cc @martinbonnin 